### PR TITLE
Assume that shared plan instances are always 'ready'

### DIFF
--- a/vendor/github.com/84codes/go-api/api/api.go
+++ b/vendor/github.com/84codes/go-api/api/api.go
@@ -28,7 +28,9 @@ func (api *API) waitUntilReady(id string) (map[string]interface{}, error) {
 		if err != nil {
 			return nil, err
 		}
-		if data["ready"] == true {
+
+		// Shared plans don't include the "ready" field, so just assume that they are.
+		if data["ready"] == true || data["plan"] == "lemur" || data["plan"] == "tiger" {
 			data["id"] = id
 			return data, nil
 		}


### PR DESCRIPTION
The terraform provider never finishes creating a `lemur` plan instance. Evidence is included.

Here is the terraform snippet:
```
resource "cloudamqp_instance" "observatory" {
  name   = "observatory"
  plan   = "lemur"
  region = "amazon-web-services::us-east-1"
}
```

Here is output from `terraform apply`
```
...
module.observatory.cloudamqp_instance.observatory: Still creating... (1h9m50s elapsed)
module.observatory.cloudamqp_instance.observatory: Still creating... (1h10m0s elapsed)
module.observatory.cloudamqp_instance.observatory: Still creating... (1h10m10s elapsed)
```

According to cloudamqp support communication:

> The ready flag is only set for dedicated plans I believe.

After applying this patch, the problem is fixed. Evidence:

```
module.observatory.cloudamqp_instance.observatory: Creating...
  apikey:     "<sensitive>" => "<sensitive>"
  name:       "" => "observatory"
  nodes:      "" => "1"
  plan:       "" => "lemur"
  region:     "" => "amazon-web-services::us-east-1"
  url:        "<sensitive>" => "<sensitive>"
  vpc_subnet: "" => "REDACTED"
module.observatory.data.local_file.automation_key: Refreshing state...
module.observatory.cloudamqp_instance.observatory: Creation complete after 2s (ID: 59428)
```